### PR TITLE
Fix detection range setting

### DIFF
--- a/pypi/mh_z19/__init__.py
+++ b/pypi/mh_z19/__init__.py
@@ -107,18 +107,18 @@ def zero_point_calibration():
 def detection_range_5000():
   ser = connect_serial()
   if p_ver == '2':
-    request = "\xff\x01\x99\x13\x88\x00\x00\x00\xcb"
+    request = "\xff\x01\x99\x00\x00\x00\x13\x88\xcb"
   else:
-    request = b"\xff\x01\x99\x13\x88\x00\x00\x00\xcb"
+    request = b"\xff\x01\x99\x00\x00\x00\x13\x88\xcb"
   result = ser.write(request)
   ser.close()
 
 def detection_range_2000():
   ser = connect_serial()
   if p_ver == '2':
-    request = "\xff\x01\x99\x07\xd0\x00\x00\x00\xc6"
+    request = "\xff\x01\x99\x00\x00\x00\x07\xd0\xc6"
   else:
-    request = b"\xff\x01\x99\x07\xd0\x00\x00\x00\xc6"
+    request = b"\xff\x01\x99\x00\x00\x00\x07\xd0\xc6"
   result = ser.write(request)
   ser.close()
 


### PR DESCRIPTION
Hi, I've tried to fix a problem with detection range setting on MH-Z19.

If you sent the original byte sequence for changing range to 0-2000ppm or 0-5000ppm to the sensor, range actually got set to 0-1000ppm. For some reason the bytes indicating the range have to be sent in an different order. I found out thaks to this analysis here: https://revspace.nl/MHZ19#Setting_the_measurement_range.

Also, we need someone to test it on MH-Z19B too, I have only tested this with MH-Z19.