### PR TITLE
Fix JSON validity

### DIFF
--- a/pypi/mh_z19/__main__.py
+++ b/pypi/mh_z19/__main__.py
@@ -4,6 +4,7 @@
 # © Takeyuki UEDA 2015 -
 import sys
 import argparse
+import json
 import mh_z19.__init__ as mh_z19
 #import __init__ as mh_z19
 
@@ -52,6 +53,6 @@ elif args.detection_range_2000:
   print ("Set Detection range as 2000.")
 else:
   value = mh_z19.read()
-  print (value)
+  print (json.dumps(value))
 
 sys.exit(0)


### PR DESCRIPTION
The output of the command had single quotes, which are not allowed in the JSON standard. So I tried to fix this by encoding Python dict as JSON and outputting that.