### PR TITLE
adds manual encoding argument for README.md

### DIFF
--- a/pypi/setup.py
+++ b/pypi/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding='utf8') as f:
   long_description = f.read()
 
 setup(


### PR DESCRIPTION
Ok, so this change was enough to resolve the encoding problem I mentioned in issue #41. The only difference is to manually specify the encoding for README.md. I tested this branch on my Raspberry Pi and it seems to work. On Windows you do have to avoid installing RPi.GPIO, but I still get nice autocomplete in my IDE from having the package installed without the dependency.