### PR TITLE
Fix querying of pimodel

### DIFF
--- a/mh_z19.py
+++ b/mh_z19.py
@@ -19,7 +19,7 @@ import RPi.GPIO as GPIO
 
 # setting
 version = "3.1.2"
-pimodel        = getrpimodel.model
+pimodel        = getrpimodel.model()
 pimodel_strict = getrpimodel.model_strict()
 retry_count    = 3
 

--- a/pypi/mh_z19/__init__.py
+++ b/pypi/mh_z19/__init__.py
@@ -16,7 +16,7 @@ import RPi.GPIO as GPIO
 
 # setting
 version = "3.1.2"
-pimodel        = getrpimodel.model
+pimodel        = getrpimodel.model()
 pimodel_strict = getrpimodel.model_strict()
 retry_count    = 3
 


### PR DESCRIPTION
Currently the conditions `pimodel == "3 Model B" or pimodel == "4 Model B"` never are true, as `pimodel` is assigned the reference to function `getrpimodel.model` instead of its return value.
I guess it never was an issue, because `'/dev/serial0'` usually exists and takes precedence on these pi models (?) I only noticed the problem because I forgot to pass access to `'/dev/serial0'` to a docker container.